### PR TITLE
feat: add JsonCreate page with delimiter/quote options (#12)

### DIFF
--- a/src/lib/jsonToCsv.ts
+++ b/src/lib/jsonToCsv.ts
@@ -1,0 +1,105 @@
+// JSON → CSV/TSV 変換
+
+// 括り文字の指定
+export type QuoteMode =
+  | 'double' // "
+  | 'single' // '
+  | 'none' // 括らない（必要時は安全のため " にフォールバック）
+  | { kind: 'custom'; char: string }; // 任意 1 文字
+
+export type JsonToCsvOptions = {
+  delimiter: string; // 区切り文字（カスタム対応）
+  header: boolean; // ヘッダ行を出力するか
+  quote?: QuoteMode; // 括り文字の種類
+  alwaysQuote?: boolean; // ★ 追加: 常に括り文字で囲む（デフォルト false）
+};
+
+// 1行分の型
+export type JsonRecord = Record<string, unknown>;
+
+/** 括り文字の実体を取り出す */
+function resolveQuote(mode: QuoteMode | undefined): string | null {
+  if (!mode) return '"';
+  if (mode === 'double') return '"';
+  if (mode === 'single') return "'";
+  if (mode === 'none') return null;
+  // custom
+  const ch = mode.char ?? '';
+  return ch.length > 0 ? ch[0] : '"';
+}
+
+/** 値をセル文字列に変換（CSV/TSV 安全化） */
+function toCell(
+  value: unknown,
+  delimiter: string,
+  quoteMode: QuoteMode | undefined,
+  alwaysQuote = false
+): string {
+  // 値を文字列化
+  let s =
+    value === null || value === undefined
+      ? ''
+      : typeof value === 'string'
+      ? value
+      : typeof value === 'number' || typeof value === 'boolean'
+      ? String(value)
+      : JSON.stringify(value);
+
+  const q = resolveQuote(quoteMode);
+
+  // 区切り/改行/括り文字自身 を含むなら引用が必要
+  const needsQuote =
+    s.includes(delimiter) ||
+    s.includes('\n') ||
+    s.includes('\r') ||
+    (q ? s.includes(q) : false);
+
+  if (q) {
+    // 括り文字自身は二重化してエスケープ
+    if (s.includes(q)) s = s.split(q).join(q + q);
+    // ★ 変更: 「常に」または「必要時のみ」で括る
+    if (alwaysQuote || needsQuote) s = q + s + q;
+    return s;
+  }
+
+  // quote = none のときでも、区切り/改行を含むなら破損防止で " で括る
+  if (needsQuote) {
+    const esc = s.replace(/"/g, '""');
+    return `"${esc}"`;
+  }
+  return s;
+}
+
+/** JSON 配列を CSV/TSV 文字列に変換 */
+export function jsonToCsv<T extends JsonRecord>(
+  rows: T[],
+  opts: JsonToCsvOptions = { delimiter: ',', header: true, quote: 'double' }
+): string {
+  if (!Array.isArray(rows) || rows.length === 0) return '';
+
+  const delimiter = String(opts.delimiter ?? ',');
+  const quoteMode = opts.quote ?? 'double';
+  const always = !!opts.alwaysQuote;
+
+  // すべてのキーの和集合をヘッダに採用
+  const keySet = new Set<string>();
+  for (const r of rows) Object.keys(r).forEach(k => keySet.add(k));
+  const keys = Array.from(keySet);
+
+  const out: string[] = [];
+
+  if (opts.header) {
+    out.push(
+      keys.map(k => toCell(k, delimiter, quoteMode, always)).join(delimiter)
+    );
+  }
+
+  for (const r of rows) {
+    const line = keys
+      .map(k => toCell(r[k], delimiter, quoteMode, always))
+      .join(delimiter);
+    out.push(line);
+  }
+
+  return out.join('\n');
+}

--- a/src/pages/JsonCreate.tsx
+++ b/src/pages/JsonCreate.tsx
@@ -1,7 +1,207 @@
-import '../styles/style.scss';
+// src/pages/JsonCreate.tsx
+import '../styles/json.scss';
+
+import {
+  Bottom,
+  TextArea,
+  TextReplaceOptions,
+  Title,
+} from '../components/Common';
+import { useEffect, useMemo, useState } from 'react';
+import { goBack } from '../utils/goBack';
+import { jsonToCsv, type QuoteMode } from '../lib/jsonToCsv';
+
+type DelimiterPreset = 'comma' | 'tab' | 'pipe' | 'custom';
+type QuotePreset = 'double' | 'single' | 'none' | 'custom';
 
 const JsonCreate = () => {
-  return <h1>ここは、JSON作成ページです</h1>;
+  const [input, setInput] = useState(''); // 入力 JSON
+  const [preset, setPreset] = useState<DelimiterPreset>('comma');
+  const [customDelim, setCustomDelim] = useState(','); // カスタム区切り
+
+  const [quotePreset, setQuotePreset] = useState<QuotePreset>('double');
+  const [customQuote, setCustomQuote] = useState('"'); // カスタム括り
+
+  const [header, setHeader] = useState(true);
+  const [alwaysQuote, setAlwaysQuote] = useState(false); // ★ 追加: 常に括る
+  const [output, setOutput] = useState(''); // 出力
+
+  // 実際に使う区切り文字
+  const delimiter = useMemo(() => {
+    switch (preset) {
+      case 'comma':
+        return ',';
+      case 'tab':
+        return '\t';
+      case 'pipe':
+        return '|';
+      case 'custom':
+        return customDelim || ',';
+    }
+  }, [preset, customDelim]);
+
+  // 実際に使う括り文字（lib の QuoteMode 型に変換）
+  const quoteMode: QuoteMode = useMemo(() => {
+    switch (quotePreset) {
+      case 'double':
+      case 'single':
+      case 'none':
+        return quotePreset;
+      case 'custom':
+        return { kind: 'custom', char: (customQuote || '"').slice(0, 1) };
+    }
+  }, [quotePreset, customQuote]);
+
+  // 入力 or 設定が変わったら即時変換
+  useEffect(() => {
+    if (!input.trim()) {
+      setOutput('');
+      return;
+    }
+    try {
+      const parsed = JSON.parse(input) as unknown;
+      if (!Array.isArray(parsed)) {
+        setOutput(
+          '⚠ 入力はオブジェクト配列（例: [{...},{...}]）にしてください。'
+        );
+        return;
+      }
+      const result = jsonToCsv(parsed, {
+        delimiter,
+        header,
+        quote: quoteMode,
+        alwaysQuote, // ★ 追加
+      });
+      setOutput(result);
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      setOutput(`⚠ JSONの形式が不正です: ${msg}`);
+    }
+  }, [input, delimiter, header, quoteMode, alwaysQuote]);
+
+  // クリップボードコピー
+  async function handleCopy() {
+    try {
+      await navigator.clipboard.writeText(output);
+      alert('出力をコピーしました');
+    } catch {
+      alert('コピーに失敗しました');
+    }
+  }
+
+  return (
+    <div className="json">
+      <Title titleText="JSON作成" titleClass="title" />
+
+      <div className="json-section">
+        <div className="section-title">入力（JSON）</div>
+        <TextArea
+          id="json-input"
+          name="json-input"
+          rows={12}
+          placeholder="JSONを入力してください"
+          value={input}
+          onChange={setInput}
+          readonly={false}
+        />
+      </div>
+
+      <Title titleText="変換設定" titleClass="sub-title" />
+
+      <div className="json-options">
+        {/* 区切り文字 */}
+        <label className="opt">
+          <span className="opt-label">区切り文字</span>
+          <select
+            value={preset}
+            onChange={e => setPreset(e.target.value as DelimiterPreset)}
+          >
+            <option value="comma">カンマ</option>
+            <option value="tab">タブ</option>
+            <option value="pipe">パイプ（|）</option>
+            <option value="custom">カスタム</option>
+          </select>
+          {preset === 'custom' && (
+            <input
+              className="inline-input"
+              value={customDelim}
+              maxLength={2}
+              placeholder="例: ;"
+              onChange={e => setCustomDelim(e.target.value)}
+            />
+          )}
+        </label>
+
+        {/* 括り文字 */}
+        <label className="opt">
+          <span className="opt-label">括り文字</span>
+          <select
+            value={quotePreset}
+            onChange={e => setQuotePreset(e.target.value as QuotePreset)}
+          >
+            <option value="double">ダブルクォート（"）</option>
+            <option value="single">シングルクォート（'）</option>
+            <option value="none">なし</option>
+            <option value="custom">カスタム</option>
+          </select>
+          {quotePreset === 'custom' && (
+            <input
+              className="inline-input"
+              value={customQuote}
+              maxLength={1}
+              placeholder="例: `"
+              onChange={e => setCustomQuote(e.target.value)}
+            />
+          )}
+        </label>
+
+        {/* トグル群 */}
+        <div className="opt opt-toggle">
+          <TextReplaceOptions
+            id="opt-header"
+            name="opt-header"
+            spanTitle="ヘッダ行を出力する"
+            textType="checkbox"
+            checked={header}
+            onChange={setHeader}
+          />
+          <TextReplaceOptions
+            id="opt-always-quote"
+            name="opt-always-quote"
+            spanTitle="常に括り文字で囲む"
+            textType="checkbox"
+            checked={alwaysQuote}
+            onChange={setAlwaysQuote}
+          />
+        </div>
+      </div>
+
+      <Title titleText="出力" titleClass="sub-title" />
+      <div className="json-output">
+        <div className="output-header">
+          <Bottom
+            buttonText="コピー"
+            buttonClass="button-copy"
+            onClick={handleCopy}
+          />
+        </div>
+        <TextArea
+          id="json-output"
+          name="json-output"
+          rows={10}
+          placeholder="ここに出力結果が表示されます"
+          value={output}
+          readonly={true}
+        />
+      </div>
+
+      <Bottom
+        buttonText="戻る"
+        buttonClass="button-back"
+        onClick={() => goBack('/tools/#/')}
+      />
+    </div>
+  );
 };
 
 export default JsonCreate;

--- a/src/styles/json.scss
+++ b/src/styles/json.scss
@@ -1,0 +1,84 @@
+/* src/styles/json.scss */
+@use './variables' as *;
+@use './mixins' as *;
+
+.json {
+  max-width: 86.3rem;
+  margin: clamp(3rem, 5vw, 6rem) auto;
+  padding-inline: clamp(1.2rem, 4vw, 4rem);
+
+  .json-section {
+    margin-bottom: 2.5rem;
+
+    .section-title {
+      font-size: 1.6rem;
+      margin-bottom: 0.6rem;
+      text-align: center;
+    }
+  }
+
+  /* オプション行レイアウト */
+  .json-options {
+    display: grid;
+    grid-template-columns: 1fr 1fr; /* 区切り/括り + ヘッダ */
+    gap: 2rem;
+    margin-bottom: 2.5rem;
+
+    @include md {
+      grid-template-columns: 1fr;
+    }
+
+    .opt {
+      display: flex;
+      flex-direction: column;
+      gap: 0.6rem;
+
+      .opt-label {
+        font-size: 1.5rem;
+        opacity: 0.9;
+      }
+
+      select,
+      .inline-input {
+        padding: 0.6rem 0.8rem;
+        border-radius: 0.6rem;
+        border: $border;
+        background: transparent;
+        color: #00ffcc;
+      }
+
+      .inline-input {
+        margin-top: 0.4rem;
+        max-width: 16rem; /* カスタム入力幅 */
+      }
+    }
+
+    /* 見た目をオプション群に合わせたトグル */
+    .opt-toggle {
+      display: flex;
+
+      .replace-checkbox-label {
+        display: inline-flex;
+        align-items: center;
+        gap: 0.6rem;
+        font-size: 1.5rem;
+        padding: 0.6rem 0.8rem;
+        line-height: 1;
+      }
+
+      .replace-checkbox-input {
+        inline-size: 1.6rem;
+        block-size: 1.6rem;
+      }
+    }
+  }
+
+  .json-output {
+    .output-header {
+      display: flex;
+      align-items: center;
+      justify-content: flex-end;
+      margin-bottom: 1rem;
+    }
+  }
+}


### PR DESCRIPTION
JSON から CSV/TSV を生成する新規ページを追加

区切り：カンマ / タブ / パイプ / カスタム

括り：ダブル / シングル / なし / カスタム

オプション：ヘッダ行を出力する、常に括り文字で囲む

入力・設定の変更に即時追従。出力のコピーに対応