### PR TITLE
Feature/json convert and create fix

### DIFF
--- a/src/lib/csvToJson.ts
+++ b/src/lib/csvToJson.ts
@@ -1,0 +1,124 @@
+// src/lib/csvToJson.ts
+
+export type QuoteMode =
+  | 'double' // "
+  | 'single' // '
+  | 'none'
+  | { kind: 'custom'; char: string };
+
+export type CsvToJsonOptions = {
+  delimiter: string; // 区切り文字（カスタム対応）
+  quote?: QuoteMode; // 括り文字
+  hasHeader: boolean; // 先頭行をヘッダとして扱う
+  skipEmptyLines?: boolean; // 空行をスキップ
+};
+
+// 1 行をフィールド配列にパース（引用と区切りに対応）
+function parseLine(
+  line: string,
+  delimiter: string,
+  quote: string | null
+): string[] {
+  const out: string[] = [];
+  let buf = '';
+  let i = 0;
+  const n = line.length;
+  let inQuote = false;
+
+  while (i < n) {
+    const ch = line[i];
+
+    if (quote && inQuote) {
+      if (ch === quote) {
+        // quote 連続ならエスケープ（ "" -> " など）
+        const next = line[i + 1];
+        if (next === quote) {
+          buf += quote;
+          i += 2;
+          continue;
+        }
+        // 閉じ
+        inQuote = false;
+        i++;
+        continue;
+      }
+      buf += ch;
+      i++;
+      continue;
+    }
+
+    if (quote && ch === quote) {
+      inQuote = true;
+      i++;
+      continue;
+    }
+
+    if (line.startsWith(delimiter, i)) {
+      out.push(buf);
+      buf = '';
+      i += delimiter.length;
+      continue;
+    }
+
+    buf += ch;
+    i++;
+  }
+
+  out.push(buf);
+  return out;
+}
+
+function resolveQuote(mode: QuoteMode | undefined): string | null {
+  if (!mode) return '"';
+  if (mode === 'double') return '"';
+  if (mode === 'single') return "'";
+  if (mode === 'none') return null;
+  const ch = mode.char ?? '';
+  return ch.length > 0 ? ch[0] : '"';
+}
+
+/** CSV/TSV 文字列 → JSON（オブジェクト配列） */
+export function csvToJson(
+  input: string,
+  opts: CsvToJsonOptions
+): Record<string, string>[] {
+  const delimiter = String(opts.delimiter ?? ',');
+  const q = resolveQuote(opts.quote);
+  const skipEmpty = !!opts.skipEmptyLines;
+
+  // 改行は CRLF/LF/CR を吸収
+  const lines = input.split(/\r\n|\n|\r/);
+
+  const rows: string[][] = [];
+  for (const raw of lines) {
+    if (skipEmpty && raw.trim() === '') continue;
+    rows.push(parseLine(raw, delimiter, q));
+  }
+  if (rows.length === 0) return [];
+
+  let headers: string[] = [];
+  let dataStart = 0;
+
+  if (opts.hasHeader) {
+    headers = rows[0].map(h => h);
+    dataStart = 1;
+  } else {
+    // col1, col2 ... を生成
+    const maxLen = rows.reduce((m, r) => Math.max(m, r.length), 0);
+    headers = Array.from({ length: maxLen }, (_, i) => `col${i + 1}`);
+  }
+
+  const out: Record<string, string>[] = [];
+  for (let r = dataStart; r < rows.length; r++) {
+    const row = rows[r];
+    const obj: Record<string, string> = {};
+    for (let c = 0; c < headers.length; c++) {
+      const key = headers[c] ?? `col${c + 1}`;
+      const val = row[c] ?? '';
+      obj[key] = val;
+    }
+    out.push(obj);
+  }
+
+  return out;
+}

--- a/src/lib/jsonToCsv.ts
+++ b/src/lib/jsonToCsv.ts
@@ -1,41 +1,38 @@
+// src/lib/jsonToCsv.ts
 // JSON → CSV/TSV 変換
 
 // 括り文字の指定
 export type QuoteMode =
   | 'double' // "
   | 'single' // '
-  | 'none' // 括らない（必要時は安全のため " にフォールバック）
+  | 'none' // 括らない（ただし壊れないよう必要時のみ " にフォールバック）
   | { kind: 'custom'; char: string }; // 任意 1 文字
 
 export type JsonToCsvOptions = {
   delimiter: string; // 区切り文字（カスタム対応）
   header: boolean; // ヘッダ行を出力するか
   quote?: QuoteMode; // 括り文字の種類
-  alwaysQuote?: boolean; // ★ 追加: 常に括り文字で囲む（デフォルト false）
 };
 
 // 1行分の型
 export type JsonRecord = Record<string, unknown>;
 
-/** 括り文字の実体を取り出す */
+/** 括り文字の実体を取り出す（none は null） */
 function resolveQuote(mode: QuoteMode | undefined): string | null {
   if (!mode) return '"';
   if (mode === 'double') return '"';
   if (mode === 'single') return "'";
   if (mode === 'none') return null;
-  // custom
   const ch = mode.char ?? '';
   return ch.length > 0 ? ch[0] : '"';
 }
 
-/** 値をセル文字列に変換（CSV/TSV 安全化） */
+/** 値をセル文字列に変換 */
 function toCell(
   value: unknown,
   delimiter: string,
-  quoteMode: QuoteMode | undefined,
-  alwaysQuote = false
+  quoteMode: QuoteMode | undefined
 ): string {
-  // 値を文字列化
   let s =
     value === null || value === undefined
       ? ''
@@ -47,22 +44,15 @@ function toCell(
 
   const q = resolveQuote(quoteMode);
 
-  // 区切り/改行/括り文字自身 を含むなら引用が必要
-  const needsQuote =
-    s.includes(delimiter) ||
-    s.includes('\n') ||
-    s.includes('\r') ||
-    (q ? s.includes(q) : false);
-
   if (q) {
-    // 括り文字自身は二重化してエスケープ
-    if (s.includes(q)) s = s.split(q).join(q + q);
-    // ★ 変更: 「常に」または「必要時のみ」で括る
-    if (alwaysQuote || needsQuote) s = q + s + q;
-    return s;
+    // ★ 選んだ括り文字がある場合は「常に括る」
+    if (s.includes(q)) s = s.split(q).join(q + q); // 自身は二重化
+    return q + s + q;
   }
 
-  // quote = none のときでも、区切り/改行を含むなら破損防止で " で括る
+  // ★ なし（none）のときは基本括らないが、壊れないようにだけ保護
+  const needsQuote =
+    s.includes(delimiter) || s.includes('\n') || s.includes('\r');
   if (needsQuote) {
     const esc = s.replace(/"/g, '""');
     return `"${esc}"`;
@@ -79,7 +69,6 @@ export function jsonToCsv<T extends JsonRecord>(
 
   const delimiter = String(opts.delimiter ?? ',');
   const quoteMode = opts.quote ?? 'double';
-  const always = !!opts.alwaysQuote;
 
   // すべてのキーの和集合をヘッダに採用
   const keySet = new Set<string>();
@@ -89,14 +78,12 @@ export function jsonToCsv<T extends JsonRecord>(
   const out: string[] = [];
 
   if (opts.header) {
-    out.push(
-      keys.map(k => toCell(k, delimiter, quoteMode, always)).join(delimiter)
-    );
+    out.push(keys.map(k => toCell(k, delimiter, quoteMode)).join(delimiter));
   }
 
   for (const r of rows) {
     const line = keys
-      .map(k => toCell(r[k], delimiter, quoteMode, always))
+      .map(k => toCell(r[k], delimiter, quoteMode))
       .join(delimiter);
     out.push(line);
   }

--- a/src/pages/JsonConvert.tsx
+++ b/src/pages/JsonConvert.tsx
@@ -1,7 +1,267 @@
-import '../styles/style.scss';
+// src/pages/JsonConvert.tsx
+import '../styles/json.scss';
+
+import {
+  Bottom,
+  TextArea,
+  TextReplaceOptions,
+  Title,
+} from '../components/Common';
+import { useEffect, useMemo, useState } from 'react';
+import { goBack } from '../utils/goBack';
+import { csvToJson, type QuoteMode } from '../lib/csvToJson';
+
+type DelimiterPreset = 'comma' | 'tab' | 'pipe' | 'custom';
+type QuotePreset = 'double' | 'single' | 'none' | 'custom';
+type IndentPreset = '2' | '4' | 'tab';
 
 const JsonConvert = () => {
-  return <h1>ここは、JSON変換ページです</h1>;
+  // 入力（CSV/TSV）
+  const [input, setInput] = useState('');
+
+  // 区切り
+  const [delimPreset, setDelimPreset] = useState<DelimiterPreset>('comma');
+  const [customDelim, setCustomDelim] = useState(',');
+
+  // 括り
+  const [quotePreset, setQuotePreset] = useState<QuotePreset>('double');
+  const [customQuote, setCustomQuote] = useState('"');
+
+  // ヘッダ & 空行
+  const [hasHeader, setHasHeader] = useState(true);
+  const [skipEmptyLines, setSkipEmptyLines] = useState(true);
+
+  // 整形（出力 JSON）
+  const [indentPreset, setIndentPreset] = useState<IndentPreset>('2');
+  const [minify, setMinify] = useState(false);
+  const [sortKeys, setSortKeys] = useState(false);
+
+  // 出力
+  const [output, setOutput] = useState('');
+
+  // 実際に使う区切り
+  const delimiter = useMemo(() => {
+    switch (delimPreset) {
+      case 'comma':
+        return ',';
+      case 'tab':
+        return '\t';
+      case 'pipe':
+        return '|';
+      case 'custom':
+        return customDelim || ',';
+    }
+  }, [delimPreset, customDelim]);
+
+  // 実際に使う括り
+  const quoteMode: QuoteMode = useMemo(() => {
+    switch (quotePreset) {
+      case 'double':
+      case 'single':
+      case 'none':
+        return quotePreset;
+      case 'custom':
+        return { kind: 'custom', char: (customQuote || '"').slice(0, 1) };
+    }
+  }, [quotePreset, customQuote]);
+
+  // 出力のインデント
+  const space = useMemo(() => {
+    if (minify) return 0;
+    if (indentPreset === 'tab') return '\t';
+    return indentPreset === '4' ? 4 : 2;
+  }, [indentPreset, minify]);
+
+  // 変換
+  useEffect(() => {
+    if (!input.trim()) {
+      setOutput('');
+      return;
+    }
+    try {
+      const rows = csvToJson(input, {
+        delimiter,
+        quote: quoteMode,
+        hasHeader,
+        skipEmptyLines,
+      });
+
+      // キーのソート（任意）
+      const normalized = sortKeys
+        ? rows.map(obj => {
+            const ent = Object.entries(obj).sort(([a], [b]) =>
+              a.localeCompare(b)
+            );
+            return Object.fromEntries(ent);
+          })
+        : rows;
+
+      setOutput(JSON.stringify(normalized, null, space));
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      setOutput(`⚠ 変換に失敗しました: ${msg}`);
+    }
+  }, [input, delimiter, quoteMode, hasHeader, skipEmptyLines, space, sortKeys]);
+
+  async function handleCopy() {
+    try {
+      await navigator.clipboard.writeText(output);
+      alert('出力をコピーしました');
+    } catch {
+      alert('コピーに失敗しました');
+    }
+  }
+
+  return (
+    <div className="json">
+      <Title titleText="JSON変換" titleClass="title" />
+
+      {/* 入力 */}
+      <div className="json-section">
+        <div className="section-title">入力</div>
+        <TextArea
+          id="csv-input"
+          name="csv-input"
+          rows={12}
+          placeholder="データを貼り付けてください"
+          value={input}
+          onChange={setInput}
+          readonly={false}
+        />
+      </div>
+
+      <Title titleText="変換設定" titleClass="sub-title" />
+
+      {/* オプション */}
+      <div className="json-options">
+        {/* 区切り */}
+        <label className="opt">
+          <span className="opt-label">区切り文字</span>
+          <select
+            value={delimPreset}
+            onChange={e => setDelimPreset(e.target.value as DelimiterPreset)}
+          >
+            <option value="comma">カンマ</option>
+            <option value="tab">タブ</option>
+            <option value="pipe">パイプ（|）</option>
+            <option value="custom">カスタム</option>
+          </select>
+          {delimPreset === 'custom' && (
+            <input
+              className="inline-input"
+              value={customDelim}
+              maxLength={2}
+              placeholder="例: ;"
+              onChange={e => setCustomDelim(e.target.value)}
+            />
+          )}
+        </label>
+
+        {/* 括り */}
+        <label className="opt">
+          <span className="opt-label">括り文字</span>
+          <select
+            value={quotePreset}
+            onChange={e => setQuotePreset(e.target.value as QuotePreset)}
+          >
+            <option value="double">ダブルクォート（"）</option>
+            <option value="single">シングルクォート（'）</option>
+            <option value="none">なし</option>
+            <option value="custom">カスタム</option>
+          </select>
+          {quotePreset === 'custom' && (
+            <input
+              className="inline-input"
+              value={customQuote}
+              maxLength={1}
+              placeholder="例: `"
+              onChange={e => setCustomQuote(e.target.value)}
+            />
+          )}
+        </label>
+
+        {/* トグル群 */}
+        <div className="opt opt-toggle">
+          <TextReplaceOptions
+            id="opt-header"
+            name="opt-header"
+            spanTitle="先頭行をヘッダとして扱う"
+            textType="checkbox"
+            checked={hasHeader}
+            onChange={setHasHeader}
+          />
+          <TextReplaceOptions
+            id="opt-skip-empty"
+            name="opt-skip-empty"
+            spanTitle="空行をスキップする"
+            textType="checkbox"
+            checked={skipEmptyLines}
+            onChange={setSkipEmptyLines}
+          />
+        </div>
+
+        {/* 整形（インデント/最小化/キーソート） */}
+        <label className="opt">
+          <span className="opt-label">インデント</span>
+          <select
+            value={indentPreset}
+            onChange={e => setIndentPreset(e.target.value as IndentPreset)}
+            disabled={minify}
+            title={minify ? '最小化が有効のため無効' : ''}
+          >
+            <option value="2">スペース 2</option>
+            <option value="4">スペース 4</option>
+            <option value="tab">タブ</option>
+          </select>
+        </label>
+
+        <div className="opt opt-toggle">
+          <TextReplaceOptions
+            id="opt-minify"
+            name="opt-minify"
+            spanTitle="最小化（詰めて出力）"
+            textType="checkbox"
+            checked={minify}
+            onChange={setMinify}
+          />
+          <TextReplaceOptions
+            id="opt-sort"
+            name="opt-sort"
+            spanTitle="キーをアルファベット順にソート"
+            textType="checkbox"
+            checked={sortKeys}
+            onChange={setSortKeys}
+          />
+        </div>
+      </div>
+
+      {/* 出力 */}
+      <Title titleText="出力" titleClass="sub-title" />
+      <div className="json-output">
+        <div className="output-header">
+          <Bottom
+            buttonText="コピー"
+            buttonClass="button-copy"
+            onClick={handleCopy}
+          />
+        </div>
+        <TextArea
+          id="json-output"
+          name="json-output"
+          rows={12}
+          placeholder="ここに JSON の出力が表示されます"
+          value={output}
+          readonly={true}
+        />
+      </div>
+
+      <Bottom
+        buttonText="戻る"
+        buttonClass="button-back"
+        onClick={() => goBack('/tools/#/')}
+      />
+    </div>
+  );
 };
 
 export default JsonConvert;

--- a/src/pages/JsonCreate.tsx
+++ b/src/pages/JsonCreate.tsx
@@ -23,7 +23,6 @@ const JsonCreate = () => {
   const [customQuote, setCustomQuote] = useState('"'); // カスタム括り
 
   const [header, setHeader] = useState(true);
-  const [alwaysQuote, setAlwaysQuote] = useState(false); // ★ 追加: 常に括る
   const [output, setOutput] = useState(''); // 出力
 
   // 実際に使う区切り文字
@@ -40,7 +39,7 @@ const JsonCreate = () => {
     }
   }, [preset, customDelim]);
 
-  // 実際に使う括り文字（lib の QuoteMode 型に変換）
+  // UI値 -> ライブラリの QuoteMode へ
   const quoteMode: QuoteMode = useMemo(() => {
     switch (quotePreset) {
       case 'double':
@@ -69,15 +68,14 @@ const JsonCreate = () => {
       const result = jsonToCsv(parsed, {
         delimiter,
         header,
-        quote: quoteMode,
-        alwaysQuote, // ★ 追加
+        quote: quoteMode, // セレクトの指定を常時適用（none は例外扱い）
       });
       setOutput(result);
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err);
       setOutput(`⚠ JSONの形式が不正です: ${msg}`);
     }
-  }, [input, delimiter, header, quoteMode, alwaysQuote]);
+  }, [input, delimiter, header, quoteMode]);
 
   // クリップボードコピー
   async function handleCopy() {
@@ -139,9 +137,9 @@ const JsonCreate = () => {
             value={quotePreset}
             onChange={e => setQuotePreset(e.target.value as QuotePreset)}
           >
+            <option value="none">なし</option>
             <option value="double">ダブルクォート（"）</option>
             <option value="single">シングルクォート（'）</option>
-            <option value="none">なし</option>
             <option value="custom">カスタム</option>
           </select>
           {quotePreset === 'custom' && (
@@ -155,7 +153,7 @@ const JsonCreate = () => {
           )}
         </label>
 
-        {/* トグル群 */}
+        {/* ヘッダ */}
         <div className="opt opt-toggle">
           <TextReplaceOptions
             id="opt-header"
@@ -164,14 +162,6 @@ const JsonCreate = () => {
             textType="checkbox"
             checked={header}
             onChange={setHeader}
-          />
-          <TextReplaceOptions
-            id="opt-always-quote"
-            name="opt-always-quote"
-            spanTitle="常に括り文字で囲む"
-            textType="checkbox"
-            checked={alwaysQuote}
-            onChange={setAlwaysQuote}
           />
         </div>
       </div>


### PR DESCRIPTION
## 概要
- JsonCreate ページの括り文字制御を、セレクトの選択内容に完全準拠する形へ刷新しました
  - ダブル/シングル/カスタム → 常時その文字で括る
  - なし → 基本は括らないが、セル破損を防ぐため区切り・改行がある場合のみ " で保護
- 「常に括り文字で囲む」チェックボックスは削除しました
- jsonToCsv の引用処理ロジックを一本化し、UI仕様と1:1で対応付け

## 変更点
- `src/pages/JsonCreate.tsx` UI と変換トリガーの整理
- `src/lib/jsonToCsv.ts` QuoteMode の実挙動を明確化（none時フォールバック）
- スタイルの微調整（セレクト/インライン入力）

## 動作確認
- カンマ/タブ/パイプ/カスタムの各区切りで期待通りに区切られる
- 括り文字: ダブル/シングル/カスタム → 常時引用。`"のエスケープ(→"")`が正しく動く
- 括り文字: なし → 区切り/改行を含むセルのみ " で自動引用される
- ヘッダ出力 ON/OFF が正しく反映される
- スマホ幅でもUI崩れなし


## 移行/互換性
- 既存の出力は「常に括る」を使っていた場合、セレクトの選択に置き換えれば同等の結果になります
- 追加の breaking change なし

